### PR TITLE
7章 依存性の逆転

### DIFF
--- a/app/seventh/ObjectA.php
+++ b/app/seventh/ObjectA.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace seventh;
+
+class ObjectA
+{
+    private ObjectB $objectB;
+}

--- a/app/seventh/UserApplicationService.php
+++ b/app/seventh/UserApplicationService.php
@@ -4,7 +4,7 @@ namespace seventh;
 
 class UserApplicationService
 {
-    public function __construct(private readonly UserRepository $userRepository)
+    public function __construct(private readonly IUserRepository $userRepository)
     {
     }
 }

--- a/app/seventh/UserApplicationService.php
+++ b/app/seventh/UserApplicationService.php
@@ -8,6 +8,7 @@ class UserApplicationService
 
     public function __construct()
     {
+        // 依存解決が設定されていないのでエラーを起こす
         $this->userRepository = ServiceLocator::resolve();
     }
 

--- a/app/seventh/UserApplicationService.php
+++ b/app/seventh/UserApplicationService.php
@@ -4,7 +4,10 @@ namespace seventh;
 
 class UserApplicationService
 {
-    public function __construct(private readonly IUserRepository $userRepository)
+    private readonly IUserRepository $userRepository;
+
+    public function __construct()
     {
+        $this->userRepository = new InMemoryUserRepository();
     }
 }

--- a/app/seventh/UserApplicationService.php
+++ b/app/seventh/UserApplicationService.php
@@ -8,6 +8,7 @@ class UserApplicationService
 
     public function __construct()
     {
-        $this->userRepository = new InMemoryUserRepository();
+//        $this->userRepository = new InMemoryUserRepository();
+        $this->userRepository = new UserRepository();
     }
 }

--- a/app/seventh/UserApplicationService.php
+++ b/app/seventh/UserApplicationService.php
@@ -12,4 +12,4 @@ class UserApplicationService
     }
 }
 
-ServiceLocator::register(InMemoryUserRepository::class);
+ServiceLocator::register(UserRepository::class);

--- a/app/seventh/UserApplicationService.php
+++ b/app/seventh/UserApplicationService.php
@@ -10,6 +10,11 @@ class UserApplicationService
     {
         $this->userRepository = ServiceLocator::resolve();
     }
+
+    public function register(UserRegisterCommand $command): void
+    {
+
+    }
 }
 
 ServiceLocator::register(UserRepository::class);

--- a/app/seventh/UserApplicationService.php
+++ b/app/seventh/UserApplicationService.php
@@ -8,7 +8,8 @@ class UserApplicationService
 
     public function __construct()
     {
-//        $this->userRepository = new InMemoryUserRepository();
-        $this->userRepository = new UserRepository();
+        $this->userRepository = ServiceLocator::resolve();
     }
 }
+
+ServiceLocator::register(InMemoryUserRepository::class);

--- a/app/seventh/UserApplicationService.php
+++ b/app/seventh/UserApplicationService.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace seventh;
+
+class UserApplicationService
+{
+    public function __construct(private readonly UserRepository $userRepository)
+    {
+    }
+}

--- a/app/seventh/UserApplicationService.php
+++ b/app/seventh/UserApplicationService.php
@@ -5,11 +5,13 @@ namespace seventh;
 class UserApplicationService
 {
     private readonly IUserRepository $userRepository;
+    private readonly IFooRepository $fooRepository;
 
     public function __construct()
     {
         // 依存解決が設定されていないのでエラーを起こす
-        $this->userRepository = ServiceLocator::resolve();
+        $this->userRepository = ServiceLocator::resolveUser();
+        $this->fooRepository = ServiceLocator::resoleveFoo();
     }
 
     public function register(UserRegisterCommand $command): void

--- a/app/seventh/UserApplicationService2.php
+++ b/app/seventh/UserApplicationService2.php
@@ -1,4 +1,13 @@
 <?php
 
+readonly class UserApplicationService
+{
+    public function __construct(
+        private IUserRepository $userRepository,
+        private IFooRepository $fooRepository
+    ) {
+    }
+}
+
 $userRepository = new InMemoryUserRepository();
 $userApplicationService = new UserApplicationService($userRepository);

--- a/app/seventh/UserApplicationService2.php
+++ b/app/seventh/UserApplicationService2.php
@@ -1,0 +1,4 @@
+<?php
+
+$userRepository = new InMemoryUserRepository();
+$userApplicationService = new UserApplicationService($userRepository);

--- a/app/seventh/UserRepository.php
+++ b/app/seventh/UserRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace seventh;
+
+interface IUserRepository
+{
+    public function find(UserId $userId): User;
+}
+
+class UserRepository implements IUserRepository
+{
+    public function find(UserId $userId): User
+    {
+        // TODO: Implement find() method.
+    }
+}

--- a/app/seventh/test.php
+++ b/app/seventh/test.php
@@ -1,0 +1,4 @@
+<?php
+
+ServiceLocator::register(InMemoryUserRepository::class);
+$userApplicationService = new \seventh\UserApplicationService();


### PR DESCRIPTION
## 大事と思ったこと
- 依存関係逆転の法則の定義
A. 上位レベルのモジュールは下位レベルのモジュールに依存してはならない。どちらのモジュールも抽象に依存すべきである
→ 下位モジュール（リポジトリ）をインターフェースにしてそこにサービスを依存させる
B. 抽象は実装の詳細に依存してはならない。実装の詳細が抽象に依存すべきである
→ 方針の主導権をAplicationServiceに握らせることで実現できる

- 依存性を解決する方法として２パターンある
1. ServiceLocatorパターン
→ 外部から必要なクラスが見えないこと、テストを実行するまでテストがこけることがわからないこと等があり、アンチパターンとされている
2. IoCコンテナ（DIコンテナ）パターン
→ コンストラクタ経由で外から依存性を注入する

## 思ったこと
ここではLaravelでも出てくるサービスコンテナに関わる話がでてきた。
ServiceLocatorはapp()->make()を使った依存の解決。
IoCはコンストラクタ/メソッドインジェクション
LaravelではどちらもServiceProviderでの登録を経由しているのであまり意識していなかったが、やはりapp()->make()極力避けるべきと感じた。（IoCパターンもLaravelだとテスト実行まで気づきにくいが....）